### PR TITLE
fix spelling

### DIFF
--- a/lib/Catmandu/Exporter/Stat.pm
+++ b/lib/Catmandu/Exporter/Stat.pm
@@ -224,18 +224,18 @@ Catmandu::Exporter::Stat - a statistical export
 
 =head1 DESCRIPTION
 
-The L<Catmandu::Stat> package can be used to calculate statistics on the availablity of
+The L<Catmandu::Stat> package can be used to calculate statistics on the availability of
 fields in a data file. Use this exporter to count the availability of fields or count
 the number of duplicate values. For each field the exporter calculates the following
 statistics:
 
   * name    : the name of a field
-  * count   : the number of occurences of a field in all records
+  * count   : the number of occurrences of a field in all records
   * zeros   : the number of records without a field
   * zeros%  : the percentage of records without a field
-  * min     : the minimum number of occurences of a field in any record
-  * max     : the maximum number of occurences of a field in any record
-  * mean    : the mean number of occurences of a field in all records
+  * min     : the minimum number of occurrences of a field in any record
+  * max     : the maximum number of occurrences of a field in any record
+  * mean    : the mean number of occurrences of a field in all records
   * variance : the variance of the field number
   * stdev   : the standard deviation of the field number
   * uniq~   : the estimated number of unique records


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Catmandu-Stat.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcatmandu-stat-perl/raw/master/./debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
